### PR TITLE
docs: Update README.md to document the seq field

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ Keeps the connection alive.
 
 #### `broadcast`
 
-Sent by the server to clients when a message is published to a channel they are subscribed to.
+Sent by the server to clients when a message is published to a channel they are subscribed to. The `seq` field is an incrementing integer for each subscription, which can be used to detect missed events.
 
-**Params**: `{"id": "msg-123", "createTime": "2023-01-01T12:00:00Z", "channel": "channel-name", "event": "event-name", "payload": {"key": "value"}}`
+**Params**: `{"id": "msg-123", "seq": 1, "createTime": "2023-01-01T12:00:00Z", "channel": "channel-name", "event": "event-name", "payload": {"key": "value"}}`
 
 ## REST API
 

--- a/internal/broadcaster/connection.go
+++ b/internal/broadcaster/connection.go
@@ -12,7 +12,16 @@ type Connection struct {
 	Send chan Message
 
 	mu             sync.RWMutex
+	Seq            uint64
 	authentication *auth.Authentication
+}
+
+func (c *Connection) NextSeq() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.Seq++
+	return c.Seq
 }
 
 func (c *Connection) SetAuthentication(auth *auth.Authentication) {

--- a/internal/broadcaster/message.go
+++ b/internal/broadcaster/message.go
@@ -4,6 +4,7 @@ import "time"
 
 type Message struct {
 	Id         string    `json:"id"`
+	Seq        uint64    `json:"seq"`
 	CreateTime time.Time `json:"createTime"`
 	Channel    string    `json:"channel"`
 	Event      string    `json:"event"`

--- a/internal/broadcaster/registry.go
+++ b/internal/broadcaster/registry.go
@@ -69,8 +69,11 @@ func (r *InMemoryRegistry) Broadcast(message Message) {
 	var staleConnectionIds []string
 
 	for _, connection := range connections {
+		msg := message
+		msg.Seq = connection.NextSeq()
+
 		select {
-		case connection.Send <- message:
+		case connection.Send <- msg:
 		default:
 			r.logger.Warn("connection send channel is full, closing connection",
 				zap.String("connectionId", connection.Id))

--- a/internal/server/websocket.go
+++ b/internal/server/websocket.go
@@ -52,6 +52,7 @@ func (s *WebSocketServer) Register(router *mux.Router) {
 		broadcasterConn := &broadcaster.Connection{
 			Id:   connectionId,
 			Send: broascasterChannel,
+			Seq:  0,
 		}
 
 		s.registry.Connect(broadcasterConn)


### PR DESCRIPTION
This change updates the `README.md` file to include documentation for the new `seq` field in the `broadcast` notification.